### PR TITLE
Establish an initial public API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,15 @@ from `Pkg` on August 12, 2021.
 
 The public API consists of the structs
 
-* to be determined
+* `RegistryInstance`
+* `PkgInfo`
+* `PkgEntry`
 
 and the functions
 
-* to be determined
+* `reachable_registries`
+* `registry_info`
+* `compat_info`
+* `treehash`
+* `uuids_from_name`
+* `isyanked`

--- a/src/RegistryInstances.jl
+++ b/src/RegistryInstances.jl
@@ -5,12 +5,23 @@ Package providing an external source of Pkg's `RegistryInstance`
 abstraction, thus not relying on Pkg internals.
 
 Exported structs:
-* To be determined.
+* `RegistryInstance`
+* `PkgInfo`
+* `PkgEntry`
 
 Exported functions:
-* To be determined.
+* `reachable_registries`
+* `registry_info`
+* `compat_info`
+* `treehash`
+* `uuids_from_name`
+* `isyanked`
 """
 module RegistryInstances
+
+export RegistryInstance, PkgInfo, PkgEntry
+export reachable_registries, registry_info, compat_info
+export treehash, uuids_from_name, isyanked
 
 # These two functions have been lifted from Pkg's
 # `Registry/Registry.jl` file.
@@ -21,7 +32,7 @@ end
 registry_read_from_tarball() = 
     registry_use_pkg_server() && !(get(ENV, "JULIA_PKG_UNPACK_REGISTRY", "") == "true")
 
-# Initially an exact copy of Pkg's `Registry_registry_instance.jl`.
+# Initially an exact copy of Pkg's `Registry/registry_instance.jl`.
 include("registry_instance.jl")
 
 end


### PR DESCRIPTION
Closes #2.

This is still rather preliminary and open for change if practical use indicates that something more (or possibly less) is needed.